### PR TITLE
Add o3-pro model support

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -13,6 +13,7 @@ model_proxy = {
     "o1": "o1-2024-12-18",
     "o3-mini": "o3-mini-2025-01-31",
     "o3-mini-high": "o3-mini-high-2025-01-31",
+    "o3-pro": "o3-pro-2025-01-31",
     "claude-3-opus": "claude-3-opus-20240229",
     "claude-3-sonnet": "claude-3-sonnet-20240229",
     "claude-3-haiku": "claude-3-haiku-20240307",

--- a/chatgpt/ChatService.py
+++ b/chatgpt/ChatService.py
@@ -151,6 +151,8 @@ class ChatService:
             self.req_model = "o3-mini-low"
         elif "o3-mini" in self.origin_model:
             self.req_model = "o3-mini"
+        elif "o3-pro" in self.origin_model:
+            self.req_model = "o3-pro"
         elif "o3" in self.origin_model:
             self.req_model = "o3"
         elif "o1-preview" in self.origin_model:


### PR DESCRIPTION
## Summary
- support `o3-pro` model name in `ChatService`
- map `o3-pro` to `o3-pro-2025-01-31` in `model_proxy`

## Testing
- `python -m py_compile chatgpt/ChatService.py api/models.py`

------
https://chatgpt.com/codex/tasks/task_b_68510c690c188323b1a85a31e96b9fab